### PR TITLE
[CI] Renamed master to main

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -54,7 +54,7 @@ jobs:
           nix-build # Basically a `hugo` command
 
       - name: Deploy to branch
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           cd ${{ github.workspace }}/src/hugo-pages/
 


### PR DESCRIPTION
Previously, the deploy condition named `master`, while it should name `main`.