### PR TITLE
[Notes] Iridium Bankrupt Notes for Article

### DIFF
--- a/hugo-docs/restricted/notes/iridium_bankrupt.md
+++ b/hugo-docs/restricted/notes/iridium_bankrupt.md
@@ -1,3 +1,18 @@
 # Iridium, Bankrupt, Is Planning a Fiery Ending for Its 88 Satellites
 
 See [The New York Times](https://www.nytimes.com/2000/04/11/business/iridium-bankrupt-is-planning-a-fiery-ending-for-its-88-satellites.html)
+
+- Iridium was a start-up intending to deliver communication "with anyone, anytime, virtually anywhere in the world"
+	- Company put $5 Billion in satellite constellation
+	- However, there were too little subscribers
+	- Company went bankrupt in the end
+- Problem was long development time and poor marketing
+	- But the service worked well for disconnected regions
+		- e.g., traveling in life-hostile regions meant usually having no service at all
+		- SatCom allowed having service
+
+## After the Article
+
+- Iridium starts shooting up satellites again
+- Norad has currently data of 100+ satellites
+	- long period after 2000 with 31 satellites


### PR DESCRIPTION
Notes for the "Iridium, Bankrupt, Is Planning a Fiery Ending for Its 88 Satellites.

Aside from economical stuff, I learned that there is a problem in my counting as only those satellites that are current up are incorporated in my satistics.