### PR TITLE
[Infrastructure] Added .idea to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 result
 build
 .DS_STORE
+/.idea
 
 *.aux
 *.bcf


### PR DESCRIPTION
Adds .idea to gitignore to prevent it from being added to the repository. This is a common practice for IntelliJ IDEA projects. This commit is part of the infrastructure changes to the project. 