### PR TITLE
[Fix] Added source platform to measurement data from single measurement downloader

### DIFF
--- a/src/harvester/producers/ripe-single-result-prod/src/main.ts
+++ b/src/harvester/producers/ripe-single-result-prod/src/main.ts
@@ -29,6 +29,7 @@ const main = async () => {
 
 		const results = await (await (fetch(result_url))).json();
 		for (const result of results) {
+			result.source_platform = "RIPE ATLAS (single measurement)";
 			const message = JSON.stringify(result);
 			await producer.send(message);
 		}


### PR DESCRIPTION
The source platform was missing in the resulting database. That was due to the fact that the single measurement downloader did not add that information to the data sent to Kafka. Therefore, the source platform was known as `undefined` in the database.