### PR TITLE
[Experiment] 1-day downloads for each Starlink probe

### DIFF
--- a/src/harvester/producers/ripe-prod/package-lock.json
+++ b/src/harvester/producers/ripe-prod/package-lock.json
@@ -11,8 +11,6 @@
         "@codetailor/split-json": "^1.0.3",
         "@types/node": "^20.12.7",
         "@types/ws": "^8.5.10",
-        "all": "*",
-        "bufferutil": "*",
         "kafkajs": "^2.2.4",
         "stream-json": "^1.8.0",
         "typescript": "^5.4.5",


### PR DESCRIPTION
This creates a different architecture for streaming events. It uses the REST API from RIPE ATLAS to download built-in measurement data from Starlink probes.
The user can define an interval for which to download the data. Due to the large amount of data, the producer will download the data in 1-day intervals.