### PR TITLE
[Data] Switched to usage of res.from instead of res.src_addr

### DIFF
--- a/src/harvester/storage-engine/src/store.controller.ts
+++ b/src/harvester/storage-engine/src/store.controller.ts
@@ -154,7 +154,7 @@ export class StoreController {
     for (const body of el_list) {
       const msm_id = body.msm_id;
       const destination = body.dst_addr;
-      const source = body.src_addr;
+      const source = body.from;
       const result = JSON.stringify(body.result);
       let timestamp = body.timestamp;
       if (timestamp === undefined) {


### PR DESCRIPTION
Previously, the returned attribute `response.src_addr` was used, which was the local IP address of the probe. This is useless. However, the external IP address is in the field `response.from`. 