### PR TITLE
[Fix] Proper Connection String for Backup of Postgres to DuckDB

### DIFF
--- a/src/db-controller/duckdb-image/sync.sh
+++ b/src/db-controller/duckdb-image/sync.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export HOST=vm-robert-richter.cloud.dhclab.i.hpi.de
+export HOST=postgres
 
 mkdir -p data
 while true; do


### PR DESCRIPTION
Changes the host to hostname of postgres within Docker network. 