### PR TITLE
[Fix] Adding option Z to volume of jupyter notebook

### DIFF
--- a/src/db-controller/docker-compose.yml
+++ b/src/db-controller/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     ports:
       - 8888:8888
     volumes:
-      - .:/home/jovyan
+      - .:/home/jovyan:Z
 
   duckdb:
     container_name: duckdb


### PR DESCRIPTION
The volume was often read-only. By applying the Z option, the problem is hopefully fixed.