### PR TITLE
[Fix] Ill-Formatted Debug Statement

### DIFF
--- a/src/producers/ripe-atlas/src/main.ts
+++ b/src/producers/ripe-atlas/src/main.ts
@@ -107,7 +107,7 @@ const download_and_store = async (chunk: ProbeServerPair[], source_platform: str
 						parentPort.postMessage(data);
 					}
 				} catch (e) {
-					console.warn('Was not able to parse JSON returned from ${url}.');
+					console.warn(`Was not able to parse JSON returned from ${url}.`);
 				}
 			}
 


### PR DESCRIPTION
The producers return a debug statement similar to the following:

```bash
Was not able to parse JSON returned from ${url}
```