### PR TITLE
[Nix] Add hash provided by CI

### DIFF
--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -4,7 +4,7 @@ let
   hashes = import ./hashes.nix;
   # nixos-24.05
   ref = "2527da1ef492c495d5391f3bcf9c1dd9f4514e32";
-  hash = "0q96nxw7jg9l9zlpa3wkma5xzmgkdnnajapwhgb2fk2ll224rgs1";
+  hash = "06cvqh2a6z9fccf6wkch60z6s5jxwvhayjr16kmqm2vdzwnra4sx";
 
   fetchCommit = fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/${ref}.tar.gz";


### PR DESCRIPTION
Hash of nixpkgs had a mismatch. This provides hash that the CI provides. 