### PR TITLE
[Fix] Changed format of timestamp to integer in table ping_data

### DIFF
--- a/src/db-controller/schema-generator/sql/setup_queries.sql
+++ b/src/db-controller/schema-generator/sql/setup_queries.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS ping_data (
 	result VARCHAR,
 	country VARCHAR,
 	prb_id INTEGER,
-	timestamp VARCHAR,
+	timestamp INTEGER,
 	msm_type VARCHAR,
 	step INTEGER,
 	sent_packets INTEGER,

--- a/src/producers/ripe-atlas/src/store.controller.ts
+++ b/src/producers/ripe-atlas/src/store.controller.ts
@@ -54,7 +54,7 @@ const storePingData = (data: PingData[]) => {
         '${body.country}',
         ${body.prb_id},
         '${JSON.stringify(body.result)}',
-        '${timestamp}',
+        ${timestamp},
         'ping',
         ${body.step},
         ${body.sent},


### PR DESCRIPTION
Previously, timestamp field in table ping_data was a varchar. Still, it was always given as UNIX epoch and it is easier, if it is handled as an Integer in the DB.