### PR TITLE
Use matrix for gitlab ci/cd and fix artifacts path

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,35 +19,19 @@
 stages:
     - build
 
-default:
+build:
     image: registry.gitlab.com/islandoftex/images/texlive:TL2024-2024-10-20-full
-
-.build-command: &build-command latexmk -pdf -output-directory="out" -aux-directory="out" -interaction=nonstopmode main.tex
-
-proposal:
     stage: build
+    parallel:
+        matrix:
+            - DOCUMENT: [proposal, thesis]
     script:
-        - cd ./tex/proposal
-        - *build-command
-        - mv out/main.pdf proposal.pdf
+        - cd ./tex/${DOCUMENT}
+        - latexmk -pdf -output-directory="out" -aux-directory="out" -interaction=nonstopmode main.tex
     artifacts:
-        untracked: false
+        name: "${DOCUMENT}"
         when: on_success
         access: all
         expire_in: 30 days
         paths:
-            - proposal.pdf
-
-thesis:
-    stage: build
-    script:
-        - cd ./tex/thesis
-        - *build-command
-        - mv out/main.pdf out/thesis.pdf
-    artifacts:
-        untracked: false
-        when: on_success
-        access: all
-        expire_in: 30 days
-        paths:
-            - thesis.pdf
+            - ./tex/${DOCUMENT}/out/main.pdf


### PR DESCRIPTION
This pull request includes significant changes to the `.gitlab-ci.yml` file to streamline and consolidate the build process for LaTeX documents. The most important changes involve restructuring the build stages and utilizing a matrix to handle different document types.

Improvements to build process:

* Changed the `default` stage to `build` and updated the image to use `registry.gitlab.com/islandoftex/images/texlive:TL2024-2024-10-20-full`. (`.gitlab-ci.yml`)
* Removed the `proposal` job and integrated it into a matrix under the `thesis` job, allowing both `proposal` and `thesis` documents to be built using the same script. (`.gitlab-ci.yml`)
* Added a `parallel` matrix configuration to the `thesis` job to handle both `proposal` and `thesis` document types. (`.gitlab-ci.yml`)
* Updated the `script` section to dynamically change directories and build the specified document type using `latexmk`. (`.gitlab-ci.yml`)
* Modified the `artifacts` section to name the artifacts based on the document type and specify the correct output path. (`.gitlab-ci.yml`) (F