### PR TITLE
[Infrastructure] Removing DuckDB from docker-compose

### DIFF
--- a/src/db-controller/docker-compose.yml
+++ b/src/db-controller/docker-compose.yml
@@ -40,14 +40,6 @@ services:
     ports:
       - 81:81
 
-  duckdb:
-    container_name: duckdb
-    build: ./duckdb-image
-    ports:
-      - 5433:5000
-    volumes:
-      - ./data/duckdb/:/app/data
-
   schema-generator:
     container_name: schema-generator
     build: ./schema-generator


### PR DESCRIPTION
This pull request includes a change to the `src/db-controller/docker-compose.yml` file, where the `duckdb` service has been removed.

* [`src/db-controller/docker-compose.yml`](diffhunk://#diff-ce8fb0af82012d898b43a11e6c8c9a72bec68f5a4fc688b8bb9c9b469568df88L43-L50): Removed the `duckdb` service configuration, including its container name, build context, ports, and volumes.